### PR TITLE
Feature/GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 version: 2
 
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
   - package-ecosystem: npm
     directory: /
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,36 @@ name: Build
 on: push
 
 jobs:
-  build:
+  pinned-version-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install Node dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test
+
+      - name: Publish test coverage
+        # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  matrix-build:
     runs-on: ubuntu-latest
 
     strategy:
@@ -29,9 +58,3 @@ jobs:
 
       - name: Test
         run: yarn test
-
-      - name: Publish test coverage
-        # https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - name: Install Node dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test
+
+      - name: Publish test coverage
+        # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-after_success: npm run coverage
-node_js:
- - 18
- - 20

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dotjs-loader
 
 [![npm](https://img.shields.io/npm/v/dotjs-loader.svg)](https://www.npmjs.com/package/dotjs-loader)
-[![Build Status](https://travis-ci.org/simpleigh/dotjs-loader.svg?branch=master)](https://travis-ci.org/simpleigh/dotjs-loader)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/simpleigh/dotjs-loader/build.yml)](https://github.com/simpleigh/dotjs-loader/actions/workflows/build.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/simpleigh/dotjs-loader.svg)](https://codecov.io/gh/simpleigh/dotjs-loader)
 [![Downloads](https://img.shields.io/npm/dt/dotjs-loader.svg)](https://www.npmjs.com/package/dotjs-loader)
 [![Issues](https://img.shields.io/github/issues/simpleigh/dotjs-loader.svg)](https://github.com/simpleigh/dotjs-loader/issues)


### PR DESCRIPTION
### Why?

I haven't used Travis for a few years and am standardising on GitHub for
most personal projects.

### What?

* f15ba1a _Switch builds to GitHub actions_
* fda902d _Run builds on our explicitly pinned version of Node_
* e938a62 _Update build status badge in README.md_